### PR TITLE
feat(core): implementar MultiTenantService (#14)

### DIFF
--- a/apps/api/src/core/multi-tenat.service.spec.ts
+++ b/apps/api/src/core/multi-tenat.service.spec.ts
@@ -1,0 +1,226 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+// test/multi-tenant.service.spec.ts
+import { Repository } from 'typeorm';
+import { MultiTenantEntity } from './multi-tenant.entity';
+import { MultiTenantService } from './multi-tenat.service';
+
+class TestEntity extends MultiTenantEntity {
+	name!: string;
+}
+
+class TestTenantService extends MultiTenantService<TestEntity> {}
+
+describe('MultiTenantService', () => {
+	let service: TestTenantService;
+	let repo: jest.Mocked<Repository<TestEntity>>;
+
+	const tenantId = 1;
+
+	beforeEach(() => {
+		repo = {
+			find: jest.fn(),
+			findOne: jest.fn(),
+			findAndCount: jest.fn(),
+			save: jest.fn(),
+			create: jest.fn(),
+			update: jest.fn(),
+			delete: jest.fn(),
+			count: jest.fn(),
+		} as any;
+
+		service = new TestTenantService(repo);
+	});
+
+	// ===========================
+	// FIND METHODS
+	// ===========================
+
+	it('findAll should filter by tenant', async () => {
+		const entities = [{ id: 1, tenant_id: tenantId }] as TestEntity[];
+		repo.find.mockResolvedValue(entities);
+
+		const result = await service.findAll(tenantId);
+		expect(result).toEqual(entities);
+		expect(repo.find).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: expect.objectContaining({ tenant_id: tenantId }),
+			}),
+		);
+	});
+
+	it('findById should return entity or null', async () => {
+		const entity = { id: 1, tenant_id: tenantId } as TestEntity;
+		repo.findOne.mockResolvedValue(entity);
+
+		const result = await service.findById(tenantId, 1);
+		expect(result).toEqual(entity);
+	});
+
+	it('findByIdOrFail should throw if not found', async () => {
+		repo.findOne.mockResolvedValue(null);
+		await expect(service.findByIdOrFail(tenantId, 1)).rejects.toThrow(
+			NotFoundException,
+		);
+	});
+
+	it('findBy should filter correctly', async () => {
+		repo.find.mockResolvedValue([{ id: 1, tenant_id: tenantId }] as TestEntity[]);
+		const result = await service.findBy(tenantId, { name: 'Test' } as any);
+		expect(result).toHaveLength(1);
+	});
+
+	it('findOne should work', async () => {
+		const entity = { id: 1, tenant_id: tenantId } as TestEntity;
+		repo.findOne.mockResolvedValue(entity);
+
+		const result = await service.findOne(tenantId, { id: 1 } as any);
+		expect(result).toEqual(entity);
+	});
+
+	it('findByPage should return paginated result', async () => {
+		repo.findAndCount.mockResolvedValue([
+			[{ id: 1, tenant_id: tenantId } as TestEntity],
+			1,
+		]);
+		const result = await service.findByPage(tenantId, 1, 10);
+		expect(result.total).toBe(1);
+		expect(result.data).toHaveLength(1);
+	});
+
+	it('findByName should search with ILike', async () => {
+		repo.find.mockResolvedValue([
+			{ id: 1, name: 'Test', tenant_id: tenantId },
+		] as TestEntity[]);
+		const result = await service.findByName(tenantId, 'Test');
+		expect(result[0].name).toBe('Test');
+	});
+
+	it('findByField should search by dynamic field', async () => {
+		repo.find.mockResolvedValue([
+			{ id: 1, name: 'Field', tenant_id: tenantId },
+		] as TestEntity[]);
+		const result = await service.findByField(tenantId, 'name', 'Field');
+		expect(result[0].name).toBe('Field');
+	});
+
+	it('searchByFields should search multiple fields', async () => {
+		repo.find.mockResolvedValue([
+			{ id: 1, name: 'Search', tenant_id: tenantId },
+		] as TestEntity[]);
+		const result = await service.searchByFields(tenantId, 'Search', ['name']);
+		expect(result).toHaveLength(1);
+	});
+
+	// ===========================
+	// CREATE / UPDATE / DELETE
+	// ===========================
+
+	it('create should attach tenant_id', async () => {
+		const data = { name: 'New' };
+		const entity = { id: 1, name: 'New', tenant_id: tenantId } as TestEntity;
+
+		repo.create.mockReturnValue(entity);
+		repo.save.mockResolvedValue(entity);
+
+		const result = await service.create(tenantId, data);
+		expect(result.tenant_id).toBe(tenantId);
+	});
+
+	it('update should sanitize tenant_id', async () => {
+		const entity = { id: 1, tenant_id: tenantId } as TestEntity;
+		jest.spyOn(service, 'findByIdOrFail').mockResolvedValue(entity);
+
+		repo.update.mockResolvedValue({} as any);
+		repo.findOne.mockResolvedValue(entity);
+
+		await service.update(tenantId, 1, { tenant_id: 999, name: 'Updated' } as any);
+
+		expect(repo.update).toHaveBeenCalledWith(
+			1,
+			expect.not.objectContaining({ tenant_id: 999 }),
+		);
+	});
+
+	it('delete should soft delete entity', async () => {
+		const entity = { id: 1, tenant_id: tenantId } as TestEntity;
+		jest.spyOn(service, 'findByIdOrFail').mockResolvedValue(entity);
+
+		await service.delete(tenantId, 1);
+		expect(repo.update).toHaveBeenCalledWith(
+			1,
+			expect.objectContaining({ deleted_at: expect.any(Date) }),
+		);
+	});
+
+	it('hardDelete should call repository.delete', async () => {
+		const entity = { id: 1, tenant_id: tenantId } as TestEntity;
+		jest.spyOn(service, 'findByIdOrFail').mockResolvedValue(entity);
+
+		await service.hardDelete(tenantId, 1);
+		expect(repo.delete).toHaveBeenCalledWith(1);
+	});
+
+	// ===========================
+	// COUNT & EXISTS
+	// ===========================
+
+	it('count should return number', async () => {
+		repo.count.mockResolvedValue(5);
+		const result = await service.count(tenantId);
+		expect(result).toBe(5);
+	});
+
+	it('exists should return true if count > 0', async () => {
+		repo.count.mockResolvedValue(1);
+		const result = await service.exists(tenantId, { id: 1 } as any);
+		expect(result).toBe(true);
+	});
+
+	it('findAndCount should return tuple', async () => {
+		const entity = { id: 1, tenant_id: tenantId } as TestEntity;
+		repo.findAndCount.mockResolvedValue([[entity], 1]);
+		const result = await service.findAndCount(tenantId);
+		expect(result[1]).toBe(1);
+	});
+
+	// ===========================
+	// BATCH
+	// ===========================
+
+	it('createMany should attach tenant_id to all', async () => {
+		const entities = [
+			{ name: 'a', tenant_id: tenantId },
+			{ name: 'b', tenant_id: tenantId },
+		] as any;
+		repo.create.mockReturnValue(entities);
+		repo.save.mockResolvedValue(entities);
+
+		const result = await service.createMany(tenantId, [
+			{ name: 'a' },
+			{ name: 'b' },
+		]);
+		expect(result).toHaveLength(2);
+		expect(result[0].tenant_id).toBe(tenantId);
+	});
+
+	it('deleteMany should throw if some entities not found', async () => {
+		repo.find.mockResolvedValue([{ id: 1, tenant_id: tenantId }] as any);
+
+		await expect(service.deleteMany(tenantId, [1, 2])).rejects.toThrow(
+			NotFoundException,
+		);
+	});
+
+	// ===========================
+	// STATS
+	// ===========================
+
+	it('getStats should return totals', async () => {
+		repo.count
+			.mockResolvedValueOnce(10) // total
+			.mockResolvedValueOnce(8); // active
+
+		const result = await service.getStats(tenantId);
+		expect(result).toEqual({ total: 10, active: 8, deleted: 2 });
+	});
+});

--- a/apps/api/src/core/multi-tenat.service.ts
+++ b/apps/api/src/core/multi-tenat.service.ts
@@ -1,0 +1,339 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+// src/core/multitenant.service.ts
+import {
+	DeepPartial,
+	FindManyOptions,
+	FindOneOptions,
+	FindOptionsWhere,
+	ILike,
+	Repository,
+} from 'typeorm';
+import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity.js';
+import { MultiTenantEntity } from './multi-tenant.entity';
+
+export abstract class MultiTenantService<T extends MultiTenantEntity> {
+	constructor(protected repository: Repository<T>) {}
+
+	/**
+	 * Agregar tenant_id automáticamente a todas las condiciones WHERE
+	 */
+	private addTenantFilter(
+		tenantId: number,
+		whereOptions?: FindOptionsWhere<T> | FindOptionsWhere<T>[],
+	): FindOptionsWhere<T> | FindOptionsWhere<T>[] {
+		const baseFilter = { tenant_id: tenantId, deleted_at: null };
+
+		if (!whereOptions) {
+			return baseFilter as unknown as FindOptionsWhere<T>;
+		}
+
+		if (Array.isArray(whereOptions)) {
+			return whereOptions.map((condition) => ({
+				...condition,
+				...baseFilter,
+			})) as FindOptionsWhere<T>[];
+		}
+
+		return { ...whereOptions, ...baseFilter } as FindOptionsWhere<T>;
+	}
+
+	/**
+	 * Validar que la entidad pertenece al tenant
+	 */
+	private validateTenantAccess(entity: T, tenantId: number): void {
+		if (entity.tenant_id !== tenantId) {
+			throw new ForbiddenException(
+				'Access denied: Entity belongs to different tenant',
+			);
+		}
+	}
+
+	// =================================================================
+	// MÉTODOS PÚBLICOS
+	// =================================================================
+
+	async findAll(
+		tenantId: number,
+		options?: Omit<FindManyOptions<T>, 'where'>,
+	): Promise<T[]> {
+		return this.repository.find({
+			where: this.addTenantFilter(tenantId),
+			order: { id: 'DESC' } as any,
+			...options,
+		});
+	}
+
+	async findById(tenantId: number, id: number): Promise<T | null> {
+		return this.repository.findOne({
+			where: this.addTenantFilter(tenantId, {
+				id,
+			} as unknown as FindOptionsWhere<T>),
+		});
+	}
+
+	async findByIdOrFail(tenantId: number, id: number): Promise<T> {
+		const entity = await this.findById(tenantId, id);
+		if (!entity) {
+			throw new NotFoundException(
+				`Entity with ID ${id} not found for this tenant`,
+			);
+		}
+		return entity;
+	}
+
+	async findBy(
+		tenantId: number,
+		whereOptions: FindOptionsWhere<T>,
+		options?: Omit<FindManyOptions<T>, 'where'>,
+	): Promise<T[]> {
+		return this.repository.find({
+			where: this.addTenantFilter(tenantId, whereOptions),
+			...options,
+		});
+	}
+
+	async findOne(
+		tenantId: number,
+		whereOptions: FindOptionsWhere<T>,
+		options?: Omit<FindOneOptions<T>, 'where'>,
+	): Promise<T | null> {
+		return this.repository.findOne({
+			where: this.addTenantFilter(tenantId, whereOptions),
+			...options,
+		});
+	}
+
+	async create(tenantId: number, entityData: DeepPartial<T>): Promise<T> {
+		const entityWithTenant = {
+			...entityData,
+			tenant_id: tenantId,
+		} as DeepPartial<T>;
+
+		const entity = this.repository.create(entityWithTenant);
+		return this.repository.save(entity);
+	}
+
+	async update(
+		tenantId: number,
+		id: number,
+		updateData: DeepPartial<T>,
+	): Promise<T> {
+		await this.findByIdOrFail(tenantId, id);
+
+		// Type assertion seguro con verificación
+		const data = updateData as Record<string, unknown>;
+		const { tenant_id: _, ...sanitizedData } = data;
+
+		await this.repository.update(id, sanitizedData as QueryDeepPartialEntity<T>);
+		return this.findByIdOrFail(tenantId, id);
+	}
+
+	async delete(tenantId: number, id: number): Promise<void> {
+		// Verificar que la entidad existe y pertenece al tenant
+		await this.findByIdOrFail(tenantId, id);
+
+		// Soft delete
+		await this.repository.update(id, { deleted_at: new Date() } as any);
+	}
+
+	async hardDelete(tenantId: number, id: number): Promise<void> {
+		// Verificar que la entidad existe y pertenece al tenant
+		await this.findByIdOrFail(tenantId, id);
+
+		await this.repository.delete(id);
+	}
+
+	// =================================================================
+	// MÉTODOS DE PAGINACIÓN
+	// =================================================================
+
+	async findByPage(
+		tenantId: number,
+		page = 1,
+		pageSize = 10,
+		whereOptions?: FindOptionsWhere<T>,
+		options?: Omit<FindManyOptions<T>, 'where' | 'take' | 'skip'>,
+	) {
+		const skip = (page - 1) * pageSize;
+
+		const [data, total] = await this.repository.findAndCount({
+			where: this.addTenantFilter(tenantId, whereOptions),
+			order: { id: 'DESC' } as any,
+			take: pageSize,
+			skip,
+			...options,
+		});
+
+		return {
+			data,
+			total,
+			current_page: page,
+			last_page: Math.ceil(total / pageSize),
+			per_page: pageSize,
+			from: skip + 1,
+			to: skip + data.length,
+		};
+	}
+
+	// =================================================================
+	// MÉTODOS DE BÚSQUEDA
+	// =================================================================
+
+	async findByName(
+		tenantId: number,
+		name: string,
+		options?: Omit<FindManyOptions<T>, 'where'>,
+	): Promise<T[]> {
+		return this.repository.find({
+			where: this.addTenantFilter(tenantId, {
+				name: ILike(`%${name}%`),
+			} as unknown as FindOptionsWhere<T>),
+			...options,
+		});
+	}
+
+	async findByField(
+		tenantId: number,
+		field: keyof T,
+		value: any,
+		options?: Omit<FindManyOptions<T>, 'where'>,
+	): Promise<T[]> {
+		return this.repository.find({
+			where: this.addTenantFilter(tenantId, {
+				[field]: value,
+			} as FindOptionsWhere<T>),
+			...options,
+		});
+	}
+
+	async searchByFields(
+		tenantId: number,
+		searchTerm: string,
+		fields: (keyof T)[],
+		options?: Omit<FindManyOptions<T>, 'where'>,
+	): Promise<T[]> {
+		const whereConditions = fields.map((field) => ({
+			...this.addTenantFilter(tenantId),
+			[field]: ILike(`%${searchTerm}%`),
+		})) as FindOptionsWhere<T>[];
+
+		return this.repository.find({
+			where: whereConditions,
+			...options,
+		});
+	}
+
+	// =================================================================
+	// MÉTODOS DE CONTEO Y ESTADÍSTICAS
+	// =================================================================
+
+	async count(
+		tenantId: number,
+		whereOptions?: FindOptionsWhere<T>,
+	): Promise<number> {
+		return this.repository.count({
+			where: this.addTenantFilter(tenantId, whereOptions),
+		});
+	}
+
+	async exists(
+		tenantId: number,
+		whereOptions: FindOptionsWhere<T>,
+	): Promise<boolean> {
+		const count = await this.repository.count({
+			where: this.addTenantFilter(tenantId, whereOptions),
+		});
+		return count > 0;
+	}
+
+	async findAndCount(
+		tenantId: number,
+		whereOptions?: FindOptionsWhere<T>,
+		options?: Omit<FindManyOptions<T>, 'where'>,
+	): Promise<[T[], number]> {
+		return this.repository.findAndCount({
+			where: this.addTenantFilter(tenantId, whereOptions),
+			...options,
+		});
+	}
+
+	// =================================================================
+	// MÉTODOS BATCH
+	// =================================================================
+
+	async createMany(
+		tenantId: number,
+		entitiesData: DeepPartial<T>[],
+	): Promise<T[]> {
+		const entitiesWithTenant = entitiesData.map((data) => ({
+			...data,
+			tenant_id: tenantId,
+		})) as DeepPartial<T>[];
+
+		const entities = this.repository.create(entitiesWithTenant);
+		return this.repository.save(entities);
+	}
+
+	async deleteMany(tenantId: number, ids: number[]): Promise<void> {
+		// Verificar que todas las entidades pertenecen al tenant
+		const entities = await this.repository.find({
+			where: {
+				id: { $in: ids } as any,
+				tenant_id: tenantId,
+				deleted_at: null,
+			} as FindOptionsWhere<T>,
+		});
+
+		if (entities.length !== ids.length) {
+			throw new NotFoundException(
+				'Some entities not found or do not belong to this tenant',
+			);
+		}
+
+		// Soft delete batch
+		await this.repository.update(ids, { deleted_at: new Date() } as any);
+	}
+
+	// =================================================================
+	// MÉTODOS DE UTILIDAD
+	// =================================================================
+
+	async getStats(tenantId: number): Promise<{
+		total: number;
+		active: number;
+		deleted: number;
+	}> {
+		const [total, active] = await Promise.all([
+			this.repository.count({
+				where: { tenant_id: tenantId } as FindOptionsWhere<T>,
+			}),
+			this.repository.count({
+				where: {
+					tenant_id: tenantId,
+					deleted_at: null,
+				} as unknown as FindOptionsWhere<T>,
+			}),
+		]);
+
+		return {
+			total,
+			active,
+			deleted: total - active,
+		};
+	}
+
+	/**
+	 * Método para limpiar cache o realizar operaciones de mantenimiento
+	 * Implementar en clases derivadas si es necesario
+	 */
+	async clearCache?(tenantId: number): Promise<void>;
+
+	/**
+	 * Método para validaciones específicas del dominio
+	 * Implementar en clases derivadas
+	 */
+	protected async validate?(
+		tenantId: number,
+		data: DeepPartial<T>,
+	): Promise<void>;
+}

--- a/apps/api/src/docs/multi-tenant.service.md
+++ b/apps/api/src/docs/multi-tenant.service.md
@@ -1,0 +1,155 @@
+# 🏢 MultiTenantService
+
+Este servicio abstracto provee una capa genérica para manejar **entidades multi-tenant** en aplicaciones con **NestJS + TypeORM**.  
+Se encarga de aplicar automáticamente el `tenant_id` y soporta operaciones comunes como CRUD, paginación, búsquedas y soft delete.
+
+---
+
+## 🚀 Uso
+
+### 1. Crear tu entidad
+Tu entidad debe extender de `MultiTenantEntity` para heredar los campos comunes (`tenant_id`, `deleted_at`).
+
+```ts
+// src/modules/products/product.entity.ts
+import { Entity, Column } from 'typeorm';
+import { MultiTenantEntity } from 'src/core/multi-tenant.entity';
+
+@Entity('products')
+export class ProductEntity extends MultiTenantEntity {
+  @Column()
+  name: string;
+
+  @Column('decimal')
+  price: number;
+}
+```
+
+---
+
+### 2. Extender el servicio
+Crea un servicio específico para tu entidad extendiendo `MultiTenantService`.
+
+```ts
+// src/modules/products/product.service.ts
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { MultiTenantService } from 'src/core/multitenant.service';
+import { ProductEntity } from './product.entity';
+
+@Injectable()
+export class ProductService extends MultiTenantService<ProductEntity> {
+  constructor(
+    @InjectRepository(ProductEntity)
+    repository: Repository<ProductEntity>,
+  ) {
+    super(repository);
+  }
+
+  // Ejemplo: validación extra
+  protected async validate(tenantId: number, data: Partial<ProductEntity>) {
+    if (!data.name) {
+      throw new Error('El producto debe tener un nombre');
+    }
+  }
+}
+```
+
+---
+
+### 3. Usarlo en un controlador
+Pasa siempre el `tenantId` al invocar los métodos.
+
+```ts
+// src/modules/products/product.controller.ts
+import { Controller, Get, Post, Param, Body } from '@nestjs/common';
+import { ProductService } from './product.service';
+
+@Controller('products')
+export class ProductController {
+  constructor(private readonly productService: ProductService) {}
+
+  @Get(':tenantId')
+  async getAll(@Param('tenantId') tenantId: number) {
+    return this.productService.findAll(tenantId);
+  }
+
+  @Post(':tenantId')
+  async create(
+    @Param('tenantId') tenantId: number,
+    @Body() body: { name: string; price: number },
+  ) {
+    return this.productService.create(tenantId, body);
+  }
+}
+```
+
+---
+
+## 📚 Métodos disponibles
+
+### CRUD
+- `findAll(tenantId, options?)` → Lista todas las entidades del tenant.
+- `findById(tenantId, id)` → Busca por ID.
+- `findByIdOrFail(tenantId, id)` → Igual que `findById`, pero lanza `NotFoundException`.
+- `create(tenantId, data)` → Crea una nueva entidad.
+- `update(tenantId, id, data)` → Actualiza la entidad (sin permitir cambiar `tenant_id`).
+- `delete(tenantId, id)` → Soft delete.
+- `hardDelete(tenantId, id)` → Elimina físicamente.
+
+### Paginación
+- `findByPage(tenantId, page?, pageSize?, where?, options?)`
+
+### Búsquedas
+- `findByName(tenantId, name)`
+- `findByField(tenantId, field, value)`
+- `searchByFields(tenantId, searchTerm, fields)`
+
+### Estadísticas
+- `count(tenantId, where?)`
+- `exists(tenantId, where)`
+- `getStats(tenantId)` → Retorna `{ total, active, deleted }`
+
+### Batch
+- `createMany(tenantId, data[])`
+- `deleteMany(tenantId, ids[])`
+
+---
+
+## ✅ Ejemplo rápido
+
+```ts
+// Crear producto
+await productService.create(1, { name: 'Laptop', price: 1500 });
+
+// Listar productos
+await productService.findAll(1);
+
+// Paginación
+await productService.findByPage(1, 1, 10);
+
+// Buscar por nombre
+await productService.findByName(1, 'laptop');
+
+// Eliminar con soft delete
+await productService.delete(1, 5);
+
+// Estadísticas
+await productService.getStats(1);
+```
+
+---
+
+## 🛡️ Seguridad
+
+- Cada query filtra automáticamente por `tenant_id` y `deleted_at = null`.
+- No es posible actualizar el `tenant_id`.
+- Se lanzan excepciones (`ForbiddenException`, `NotFoundException`) si se intenta acceder a datos de otro tenant.
+
+---
+
+## 📌 Notas
+
+- `clearCache(tenantId)` → Método opcional a implementar en servicios concretos si necesitás limpiar cachés.
+- `validate(tenantId, data)` → Método opcional para validaciones específicas del dominio.


### PR DESCRIPTION
- MultiTenantService extiende funcionalidad de GenericService
- Todos los métodos filtran automáticamente por tenant_id
- Métodos create() inyectan tenant_id automáticamente
- Validaciones de acceso cross-tenant
- Mantiene compatibilidad con soft deletes
- Documentación y ejemplos de uso añadidos 
Closes #14 