### PR TITLE
feat(tokens): implement multi-tenant token system

### DIFF
--- a/apps/api/src/tokens/entities/tokens.entity.ts
+++ b/apps/api/src/tokens/entities/tokens.entity.ts
@@ -49,4 +49,9 @@ export class TokenEntity {
 
 	@UpdateDateColumn({ type: 'timestamp with time zone' })
 	updated_at: Date;
+
+	async getTenantId(): Promise<number> {
+		if (this.user) return this.user.tenant_id;
+		throw new Error('User not loaded');
+	}
 }

--- a/apps/api/src/tokens/tokens.service.spec.ts
+++ b/apps/api/src/tokens/tokens.service.spec.ts
@@ -1,0 +1,397 @@
+import { TenantEntity } from '@/tenants/entities/tenant.entity';
+import { RoleEntity } from '@/users/entities/role.entity';
+import { BadRequestException } from '@nestjs/common';
+// src/tokens/services/tokens.service.spec.ts
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { TokenTypes } from '@repo/common';
+import { Repository } from 'typeorm';
+import { UserEntity } from '../users/entities/user.entity';
+import { TokenEntity } from './entities/tokens.entity';
+import { TokensService } from './tokens.service';
+
+describe('TokensService', () => {
+	let tokensService: TokensService;
+	let tokenRepository: Repository<TokenEntity>;
+
+	const mockTokenRepository = {
+		save: jest.fn(),
+		findOne: jest.fn(),
+		update: jest.fn(),
+		createQueryBuilder: jest.fn(),
+	};
+
+	const mockUser: UserEntity = {
+		id: 1,
+		tenant_id: 1,
+		name: 'Test User',
+		email: 'test@example.com',
+		password: 'hashedpassword',
+		created_at: new Date(),
+		updated_at: new Date(),
+		tokens: [],
+		role: {} as RoleEntity,
+		surname: 'User',
+		tenant: {} as TenantEntity,
+	};
+
+	const mockToken: TokenEntity = {
+		id: 'token-uuid-123',
+		user_id: 1,
+		user: mockUser,
+		type: TokenTypes.CHANGE_EMAIL,
+		token_hash: 'hashed-token',
+		expires_at: new Date(Date.now() + 3600000), // 1 hora en el futuro
+		used_at: null,
+		created_at: new Date(),
+		updated_at: new Date(),
+		metadata: undefined,
+		getTenantId: async () => 1, // Mock implementation
+	};
+
+	const expiredToken: TokenEntity = {
+		...mockToken,
+		expires_at: new Date(Date.now() - 3600000), // 1 hora en el pasado
+		getTenantId: async () => 1, // Mock implementation
+	};
+
+	const usedToken: TokenEntity = {
+		...mockToken,
+		used_at: new Date(),
+		getTenantId: async () => 1, // Mock implementation
+	};
+
+	beforeEach(async () => {
+		const module: TestingModule = await Test.createTestingModule({
+			providers: [
+				TokensService,
+				{
+					provide: getRepositoryToken(TokenEntity),
+					useValue: mockTokenRepository,
+				},
+			],
+		}).compile();
+
+		tokensService = module.get<TokensService>(TokensService);
+		tokenRepository = module.get<Repository<TokenEntity>>(
+			getRepositoryToken(TokenEntity),
+		);
+
+		jest.clearAllMocks();
+	});
+
+	describe('generateToken', () => {
+		it('should generate a token successfully', async () => {
+			const options = {
+				user_id: 1,
+				type: TokenTypes.CHANGE_EMAIL,
+				expiresInHours: 24,
+				metadata: { ip: '127.0.0.1' },
+			};
+
+			mockTokenRepository.save.mockResolvedValue(mockToken);
+
+			const result = await tokensService.generateToken(options);
+
+			expect(tokenRepository.save).toHaveBeenCalledWith({
+				user_id: options.user_id,
+				metadata: options.metadata,
+				expires_at: expect.any(Date),
+				type: options.type,
+				token_hash: expect.any(String),
+				used_at: null,
+			});
+			expect(result.token).toBeDefined();
+			expect(result.expires).toBeDefined();
+		});
+	});
+
+	describe('validate', () => {
+		it('should validate token successfully with correct tenant', async () => {
+			const validateParams = {
+				user_id: 1,
+				type: TokenTypes.CHANGE_EMAIL,
+				token: 'valid-token',
+				tenantId: 1,
+			};
+
+			mockTokenRepository.findOne.mockResolvedValue(mockToken);
+
+			const result = await tokensService.validate(validateParams);
+
+			expect(tokenRepository.findOne).toHaveBeenCalledWith({
+				where: {
+					user_id: validateParams.user_id,
+					type: validateParams.type,
+					token_hash: expect.any(String),
+				},
+				relations: ['user'],
+			});
+			expect(result).toEqual(mockToken);
+		});
+
+		it('should throw BadRequestException when token not found', async () => {
+			const validateParams = {
+				user_id: 1,
+				type: TokenTypes.CHANGE_EMAIL,
+				token: 'invalid-token',
+				tenantId: 1,
+			};
+
+			mockTokenRepository.findOne.mockResolvedValue(null);
+
+			await expect(tokensService.validate(validateParams)).rejects.toThrow(
+				BadRequestException,
+			);
+		});
+
+		it('should throw BadRequestException when token expired', async () => {
+			const validateParams = {
+				user_id: 1,
+				type: TokenTypes.CHANGE_EMAIL,
+				token: 'expired-token',
+				tenantId: 1,
+			};
+
+			mockTokenRepository.findOne.mockResolvedValue(expiredToken);
+
+			await expect(tokensService.validate(validateParams)).rejects.toThrow(
+				BadRequestException,
+			);
+		});
+
+		it('should throw BadRequestException when tenant does not match', async () => {
+			const validateParams = {
+				user_id: 1,
+				type: TokenTypes.CHANGE_EMAIL,
+				token: 'valid-token',
+				tenantId: 2, // Different tenant
+			};
+
+			mockTokenRepository.findOne.mockResolvedValue(mockToken);
+
+			await expect(tokensService.validate(validateParams)).rejects.toThrow(
+				BadRequestException,
+			);
+		});
+	});
+
+	describe('validateToken', () => {
+		it('should validate token successfully with correct tenant', async () => {
+			const token = 'valid-token';
+			const tenantId = 1;
+
+			mockTokenRepository.findOne.mockResolvedValue(mockToken);
+
+			const result = await tokensService.validateToken(token, tenantId);
+
+			expect(tokenRepository.findOne).toHaveBeenCalledWith({
+				where: { token_hash: expect.any(String) },
+				relations: ['user'],
+			});
+			expect(result).toEqual(mockToken);
+		});
+
+		it('should throw BadRequestException when token not found', async () => {
+			const token = 'invalid-token';
+			const tenantId = 1;
+
+			mockTokenRepository.findOne.mockResolvedValue(null);
+
+			await expect(tokensService.validateToken(token, tenantId)).rejects.toThrow(
+				BadRequestException,
+			);
+		});
+
+		it('should throw BadRequestException when token expired', async () => {
+			const token = 'expired-token';
+			const tenantId = 1;
+
+			mockTokenRepository.findOne.mockResolvedValue(expiredToken);
+
+			await expect(tokensService.validateToken(token, tenantId)).rejects.toThrow(
+				BadRequestException,
+			);
+		});
+
+		it('should throw BadRequestException when token already used', async () => {
+			const token = 'used-token';
+			const tenantId = 1;
+
+			mockTokenRepository.findOne.mockResolvedValue(usedToken);
+
+			await expect(tokensService.validateToken(token, tenantId)).rejects.toThrow(
+				BadRequestException,
+			);
+		});
+
+		it('should throw BadRequestException when tenant does not match', async () => {
+			const token = 'valid-token';
+			const tenantId = 2; // Different tenant
+
+			mockTokenRepository.findOne.mockResolvedValue(mockToken);
+
+			await expect(tokensService.validateToken(token, tenantId)).rejects.toThrow(
+				BadRequestException,
+			);
+		});
+	});
+
+	describe('markAsUsed', () => {
+		it('should mark token as used successfully without tenant validation', async () => {
+			const tokenId = 'token-uuid-123';
+			const updateResult = { affected: 1, generatedMaps: [], raw: [] };
+
+			mockTokenRepository.update.mockResolvedValue(updateResult);
+
+			const result = await tokensService.markAsUsed(tokenId);
+
+			expect(tokenRepository.update).toHaveBeenCalledWith(tokenId, {
+				used_at: expect.any(Date),
+			});
+			expect(result).toEqual(updateResult);
+		});
+
+		it('should mark token as used successfully with matching tenant', async () => {
+			const tokenId = 'token-uuid-123';
+			const tenantId = 1;
+			const updateResult = { affected: 1, generatedMaps: [], raw: [] };
+
+			mockTokenRepository.findOne.mockResolvedValue(mockToken);
+			mockTokenRepository.update.mockResolvedValue(updateResult);
+
+			const result = await tokensService.markAsUsed(tokenId, tenantId);
+
+			expect(tokenRepository.findOne).toHaveBeenCalledWith({
+				where: { id: tokenId },
+				relations: ['user'],
+			});
+			expect(tokenRepository.update).toHaveBeenCalledWith(tokenId, {
+				used_at: expect.any(Date),
+			});
+			expect(result).toEqual(updateResult);
+		});
+
+		it('should throw BadRequestException when tenant does not match', async () => {
+			const tokenId = 'token-uuid-123';
+			const tenantId = 2; // Different tenant
+
+			mockTokenRepository.findOne.mockResolvedValue(mockToken);
+
+			await expect(tokensService.markAsUsed(tokenId, tenantId)).rejects.toThrow(
+				BadRequestException,
+			);
+		});
+
+		it('should proceed when token not found but no tenant validation', async () => {
+			const tokenId = 'non-existent-token';
+			const updateResult = { affected: 0, generatedMaps: [], raw: [] };
+
+			mockTokenRepository.update.mockResolvedValue(updateResult);
+
+			const result = await tokensService.markAsUsed(tokenId);
+
+			expect(tokenRepository.update).toHaveBeenCalledWith(tokenId, {
+				used_at: expect.any(Date),
+			});
+			expect(result).toEqual(updateResult);
+		});
+	});
+
+	describe('cleanupExpiredTokens', () => {
+		it('should cleanup expired tokens for tenant', async () => {
+			const tenantId = 1;
+			const deleteResult = { affected: 5, raw: [] };
+
+			const mockQueryBuilder = {
+				innerJoin: jest.fn().mockReturnThis(),
+				where: jest.fn().mockReturnThis(),
+				andWhere: jest.fn().mockReturnThis(),
+				delete: jest.fn().mockReturnThis(),
+				execute: jest.fn().mockResolvedValue(deleteResult),
+			};
+
+			mockTokenRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+
+			const result = await tokensService.cleanupExpiredTokens(tenantId);
+
+			expect(mockTokenRepository.createQueryBuilder).toHaveBeenCalledWith('token');
+			expect(mockQueryBuilder.innerJoin).toHaveBeenCalledWith(
+				'token.user',
+				'user',
+			);
+			expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+				'user.tenant_id = :tenantId',
+				{ tenantId },
+			);
+			expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith(
+				'token.expires_at < :now',
+				{ now: expect.any(Date) },
+			);
+			expect(mockQueryBuilder.delete).toHaveBeenCalled();
+			expect(result).toBe(5);
+		});
+
+		it('should return 0 when no tokens to cleanup', async () => {
+			const tenantId = 1;
+			const deleteResult = { affected: 0, raw: [] };
+
+			const mockQueryBuilder = {
+				innerJoin: jest.fn().mockReturnThis(),
+				where: jest.fn().mockReturnThis(),
+				andWhere: jest.fn().mockReturnThis(),
+				delete: jest.fn().mockReturnThis(),
+				execute: jest.fn().mockResolvedValue(deleteResult),
+			};
+
+			mockTokenRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+
+			const result = await tokensService.cleanupExpiredTokens(tenantId);
+
+			expect(result).toBe(0);
+		});
+	});
+
+	describe('countTokensByTenant', () => {
+		it('should count tokens for tenant', async () => {
+			const tenantId = 1;
+
+			const mockQueryBuilder = {
+				innerJoin: jest.fn().mockReturnThis(),
+				where: jest.fn().mockReturnThis(),
+				getCount: jest.fn().mockResolvedValue(10),
+			};
+
+			mockTokenRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+
+			const result = await tokensService.countTokensByTenant(tenantId);
+
+			expect(mockTokenRepository.createQueryBuilder).toHaveBeenCalledWith('token');
+			expect(mockQueryBuilder.innerJoin).toHaveBeenCalledWith(
+				'token.user',
+				'user',
+			);
+			expect(mockQueryBuilder.where).toHaveBeenCalledWith(
+				'user.tenant_id = :tenantId',
+				{ tenantId },
+			);
+			expect(result).toBe(10);
+		});
+
+		it('should return 0 when no tokens for tenant', async () => {
+			const tenantId = 2;
+
+			const mockQueryBuilder = {
+				innerJoin: jest.fn().mockReturnThis(),
+				where: jest.fn().mockReturnThis(),
+				getCount: jest.fn().mockResolvedValue(0),
+			};
+
+			mockTokenRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder);
+
+			const result = await tokensService.countTokensByTenant(tenantId);
+
+			expect(result).toBe(0);
+		});
+	});
+});

--- a/apps/api/src/tokens/tokens.service.ts
+++ b/apps/api/src/tokens/tokens.service.ts
@@ -2,7 +2,7 @@ import { createHash, randomBytes } from 'node:crypto';
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { TokenTypes } from '@repo/common';
-import { Repository } from 'typeorm';
+import { FindOptionsWhere, Repository } from 'typeorm';
 import { TokenEntity } from './entities/tokens.entity';
 
 interface TokenOptions {
@@ -18,13 +18,18 @@ export class TokensService {
 		@InjectRepository(TokenEntity)
 		private readonly tokenRepository: Repository<TokenEntity>,
 	) {}
+
 	private hashToken(token: string) {
 		return createHash('sha256').update(token).digest('hex');
 	}
+
 	async generateToken(options: TokenOptions) {
 		const token = randomBytes(32).toString('hex');
 		const tokenHash = this.hashToken(token);
-		const expires = new Date(Date.now() + options.expiresInHours * 1000);
+		const expires = new Date(
+			Date.now() + options.expiresInHours * 60 * 60 * 1000,
+		); // ✅ Fix: horas a milisegundos
+
 		await this.tokenRepository.save({
 			user_id: options.user_id,
 			metadata: options.metadata,
@@ -33,39 +38,97 @@ export class TokensService {
 			token_hash: tokenHash,
 			used_at: null,
 		});
-		return {
-			token,
-			expires,
-		};
+
+		return { token, expires };
 	}
+
+	// ✅ MÉTODO ACTUALIZADO: Con validación de tenant
 	async validate({
 		user_id,
 		type,
 		token,
+		tenantId, // Nuevo parámetro
 	}: {
 		user_id: number;
 		type: TokenTypes;
 		token: string;
+		tenantId: number;
 	}) {
 		const hash = this.hashToken(token);
 		const existToken = await this.tokenRepository.findOne({
-			where: {
-				user_id,
-				type,
-				token_hash: hash,
-			},
+			where: { user_id, type, token_hash: hash },
+			relations: ['user'], // Cargar user para validar tenant
 		});
-		if (!existToken) {
-			throw new BadRequestException('Token no encontrado');
+
+		if (!existToken) throw new BadRequestException('Token no encontrado');
+
+		// Validación de tenant
+		if (existToken.user.tenant_id !== tenantId) {
+			throw new BadRequestException('Token no válido para este tenant');
 		}
+
 		if (existToken.expires_at < new Date()) {
 			throw new BadRequestException('Token expirado');
 		}
+
 		return existToken;
 	}
-	async markAsUsed(tokenId: number) {
+
+	// ✅ NUEVO MÉTODO: Validación específica para multi-tenant
+	async validateToken(token: string, tenantId: number): Promise<TokenEntity> {
+		const hash = this.hashToken(token);
+
+		const existToken = await this.tokenRepository.findOne({
+			where: { token_hash: hash },
+			relations: ['user'],
+		});
+
+		if (!existToken) throw new BadRequestException('Token no encontrado');
+		if (existToken.user.tenant_id !== tenantId)
+			throw new BadRequestException('Token no válido para este tenant');
+		if (existToken.expires_at < new Date())
+			throw new BadRequestException('Token expirado');
+		if (existToken.used_at) throw new BadRequestException('Token ya utilizado');
+
+		return existToken;
+	}
+
+	async markAsUsed(tokenId: string, tenantId?: number) {
+		if (tenantId) {
+			const token = await this.tokenRepository.findOne({
+				where: { id: tokenId },
+				relations: ['user'],
+			});
+
+			if (token && token.user.tenant_id !== tenantId) {
+				throw new BadRequestException('Token no pertenece a este tenant');
+			}
+		}
+
 		return await this.tokenRepository.update(tokenId, {
 			used_at: new Date(),
 		});
+	}
+
+	// ✅ NUEVO: Cleanup automático por tenant
+	async cleanupExpiredTokens(tenantId: number): Promise<number> {
+		const result = await this.tokenRepository
+			.createQueryBuilder('token')
+			.innerJoin('token.user', 'user')
+			.where('user.tenant_id = :tenantId', { tenantId })
+			.andWhere('token.expires_at < :now', { now: new Date() })
+			.delete()
+			.execute();
+
+		return result.affected || 0;
+	}
+
+	// ✅ NUEVO: Contar tokens por tenant
+	async countTokensByTenant(tenantId: number): Promise<number> {
+		return await this.tokenRepository
+			.createQueryBuilder('token')
+			.innerJoin('token.user', 'user')
+			.where('user.tenant_id = :tenantId', { tenantId })
+			.getCount();
 	}
 }


### PR DESCRIPTION
- Add tenant validation to TokenService methods
- Implement validateToken method for multi-tenant validation
- Add cleanupExpiredTokens and countTokensByTenant methods
- Update markAsUsed to support string tokenId and optional tenant validation
- Add comprehensive test suite for multi-tenant token functionality
- Ensure token isolation between tenants through user relationship

BREAKING CHANGE:
- validate method now requires tenantId parameter
- markAsUsed tokenId parameter changed from number to string
- Token validation now includes tenant isolation checks

Closes: #27